### PR TITLE
build: fix alpine version, block docker registry login

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -42,12 +42,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
 
-      - name: Login to DockerHub
-        if: ${{ github.event_name != 'pull_request' }}
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+#      - name: Login to DockerHub
+#        if: ${{ github.event_name != 'pull_request' }}
+#        uses: docker/login-action@v1
+#        with:
+#          username: ${{ secrets.DOCKER_USERNAME }}
+#          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Publish to Docker Hub
         uses: docker/build-push-action@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # > docker build -t line/lfb .
 # > docker run -it -p 26656:26656 -p 26657:26657 -v ~/.lfb:/root/.lfb -v line/lfb lfb init
 # > docker run -it -p 26656:26656 -p 26657:26657 -v ~/.lfb:/root/.lfb -v line/lfb lfb start --rpc.laddr=tcp://0.0.0.0:26657 --p2p.laddr=tcp://0.0.0.0:26656
-FROM golang:1.15-alpine AS build-env
+FROM golang:1.15-alpine3.13 AS build-env
 ARG GITHUB_TOKEN=""
 ARG LFB_BUILD_OPTIONS=""
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
`Dockerfile` uses alpine latest version, but alpine 3.14 fails to build some library(snappy, rocksdb).
```
-- Detecting C compiler ABI info - failed
```
So we fix the alpine version to 3.13

And we have no public docker registry so I block docker registry action.

<!--- Describe your changes in detail -->

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I followed the [contributing guidelines](https://github.com/line/lfb/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
