### PR TITLE
feat: apply wasm opts

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -203,7 +203,7 @@ func init() {
 // NewLinkApp returns a reference to an initialized Link.
 func NewLinkApp(
 	logger log.Logger, db dbm.DB, traceStore io.Writer, loadLatest bool, skipUpgradeHeights map[int64]bool,
-	homePath string, invCheckPeriod uint, encodingConfig appparams.EncodingConfig, appOpts servertypes.AppOptions, baseAppOptions ...func(*baseapp.BaseApp),
+	homePath string, invCheckPeriod uint, encodingConfig appparams.EncodingConfig, appOpts servertypes.AppOptions, wasmOpts []wasm.Option, baseAppOptions ...func(*baseapp.BaseApp),
 ) *LinkApp {
 	appCodec := encodingConfig.Marshaler
 	legacyAmino := encodingConfig.Amino
@@ -330,6 +330,7 @@ func NewLinkApp(
 		supportedFeatures,
 		nil,
 		nil,
+		wasmOpts...,
 	)
 
 	// register the proposal types

--- a/app/sim_test.go
+++ b/app/sim_test.go
@@ -42,7 +42,7 @@ func BenchmarkFullAppSimulation(b *testing.B) {
 		}
 	}()
 
-	app := link.NewLinkApp(logger, db, nil, true, map[int64]bool{}, link.DefaultNodeHome, simapp.FlagPeriodValue, link.MakeEncodingConfig(), simapp.EmptyAppOptions{}, interBlockCacheOpt())
+	app := link.NewLinkApp(logger, db, nil, true, map[int64]bool{}, link.DefaultNodeHome, simapp.FlagPeriodValue, link.MakeEncodingConfig(), simapp.EmptyAppOptions{}, nil, interBlockCacheOpt())
 
 	// Run randomized simulation:w
 	_, simParams, simErr := simulation.SimulateFromSeed(
@@ -108,7 +108,7 @@ func TestAppStateDeterminism(t *testing.T) {
 			}
 
 			db := memdb.NewDB()
-			app := link.NewLinkApp(logger, db, nil, true, map[int64]bool{}, link.DefaultNodeHome, simapp.FlagPeriodValue, link.MakeEncodingConfig(), simapp.EmptyAppOptions{}, interBlockCacheOpt())
+			app := link.NewLinkApp(logger, db, nil, true, map[int64]bool{}, link.DefaultNodeHome, simapp.FlagPeriodValue, link.MakeEncodingConfig(), simapp.EmptyAppOptions{}, nil, interBlockCacheOpt())
 
 			fmt.Printf(
 				"running non-determinism simulation; seed %d: %d/%d, attempt: %d/%d\n",

--- a/cli_test/test_helpers.go
+++ b/cli_test/test_helpers.go
@@ -1342,6 +1342,7 @@ func newTestnetConfig(t *testing.T, genesisState map[string]json.RawMessage, cha
 		return app.NewLinkApp(val.Ctx.Logger, db, nil, true, make(map[int64]bool), val.Dir, 0,
 			encodingCfg,
 			val.Ctx.Viper,
+			nil,
 			baseapp.SetPruning(storetypes.NewPruningOptionsFromString(storetypes.PruningOptionNothing)),
 			baseapp.SetMinGasPrices(minGasPrices),
 		)

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/line/lfb-sdk v1.0.0-init.1.0.20210720072128-577c2c01cf60
 	github.com/line/ostracon v0.34.9-0.20210610071151-a52812ac9add
 	github.com/line/tm-db/v2 v2.0.0-init.1.0.20210413083915-5bb60e117524
+	github.com/prometheus/client_golang v1.11.0
 	github.com/rakyll/statik v0.1.7
 	github.com/spf13/cast v1.3.1
 	github.com/spf13/cobra v1.1.3


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Closes: https://github.com/line/lfb-sdk/issues/308
Add wasm opts to enable telemetry.

## Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/CosmWasm/wasmd/blob/93e2e669402dd96b99f223bc6176abef6e794455/cmd/wasmd/root.go#L204
The telemetry metrics is included :1317(API Server metrics).

e.g) recorded instantiate
`{"Name":"wasm.contract.instantiate","Count":1,"Rate":2.222800064086914,"Sum":22.22800064086914,"Min":22.22800064086914,"Max":22.22800064086914,"Mean":22.22800064086914,"Stddev":0,"Labels":{}}]}`

## How has this been tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I followed the [contributing guidelines](https://github.com/line/lfb/blob/master/CONTRIBUTING.md).
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
